### PR TITLE
Fixed crossing_type 

### DIFF
--- a/detpy/DETAlgs/data/alg_data.py
+++ b/detpy/DETAlgs/data/alg_data.py
@@ -149,7 +149,6 @@ class FiADEData(BaseData):
 class ImprovedDEData(BaseData):
     mutation_factor: float = 0.1
     crossover_rate: float = 0.5
-    crossing_type: CrossingType = CrossingType.BINOMIAL
 
 
 @dataclass

--- a/detpy/DETAlgs/eps_rde.py
+++ b/detpy/DETAlgs/eps_rde.py
@@ -7,7 +7,6 @@ from detpy.DETAlgs.methods.methods_eps_deag import calculate_init_epsilon_level,
 from detpy.DETAlgs.methods.methods_eps_rde import mutation, crossing, create_ranks, calculate_mutation_factors, calculate_crossover_rates
 from detpy.models.enums.basevectorschema import BaseVectorSchema
 from detpy.models.enums.boundary_constrain import fix_boundary_constraints
-from detpy.models.enums.crossingtype import CrossingType
 
 
 class EPSRDE(BaseAlg):
@@ -57,7 +56,7 @@ class EPSRDE(BaseAlg):
         fix_boundary_constraints(v_pop, self.boundary_constraints_fun)
 
         # New population after crossing
-        u_pop = crossing(self._pop, v_pop, cr=crossover_rates, crossing_type=CrossingType.EXPOTENTIAL)
+        u_pop = crossing(self._pop, v_pop, cr=crossover_rates, crossing_type=self.crossing_type)
 
         # Update values before selection
         u_pop.update_fitness_values(self._function.eval, self.parallel_processing)


### PR DESCRIPTION
Removed the unused crossing_type parameter from the ImprovedDE algorithm. Fixed a minor issue where the crossing_type parameter was not used during the crossing operation in the EPSRDE algorithm.